### PR TITLE
Fix: update discord link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,7 +82,7 @@ const config: Config = {
           items: [
             {
               label: 'Discord',
-              href: 'https://discord.gg/AAKVZW4cUv',
+              href: 'https://discord.gg/DezJ8GPm',
             },
             {
               label: 'Twitter',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,7 +82,7 @@ const config: Config = {
           items: [
             {
               label: 'Discord',
-              href: 'https://discord.gg/DezJ8GPm',
+              href: 'https://discord.gg/AAKVZW4cUv',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
create discord link that does not expire